### PR TITLE
Add load image support in pointillism [GCI]

### DIFF
--- a/activity.py
+++ b/activity.py
@@ -178,9 +178,12 @@ class Activity(activity.Activity):
         if result == Gtk.ResponseType.ACCEPT:
             jobject = chooser.get_selected_object()
             self.image_id = str(jobject._object_id)
-        print(str(jobject.get_file_path()))
-        puntillism.Puntillism.file_path = str(jobject.get_file_path())
-        return str(jobject.get_file_path())
+        try:
+            print(str(jobject.get_file_path()))
+            puntillism.Puntillism.file_path = str(jobject.get_file_path())
+            return str(jobject.get_file_path())
+        except (UnboundLocalError, NameError):
+            return None
 
     def get_preview(self):
         return self._pygamecanvas.get_preview()

--- a/activity.py
+++ b/activity.py
@@ -156,7 +156,7 @@ class Activity(activity.Activity):
 
     def save_image(self, image):
         journalobj = datastore.create()
-        journalobj.metadata['title'] = ('Pointillism')
+        journalobj.metadata['title'] = _('Pointillism')
         journalobj.metadata['mime_type'] = 'image/jpeg'
 
         file_path = os.path.join(os.environ['SUGAR_ACTIVITY_ROOT'], 'data', 'pointillism.jpg')

--- a/activity.py
+++ b/activity.py
@@ -22,26 +22,25 @@
 # Alan Aguiar <alanjas@gmail.com>
 # Nirav Patel <sugarlabs@spongezone.net>
 
+import puntillism
+from gettext import gettext as _
+from sugar3.datastore import datastore
+from sugar3.graphics.objectchooser import ObjectChooser
+from sugar3.graphics.toolbutton import ToolButton
+from sugar3.activity.widgets import StopButton
+from sugar3.activity.widgets import ActivityToolbarButton
+from sugar3.graphics.toolbarbox import ToolbarBox
+from sugar3.activity import activity
+from sugar3 import mime
+import sugargame.canvas
+import sugargame
+import pygame
+from gi.repository import Gtk
+from gi.repository import Gdk
 import os
 import gi
 gi.require_version('Gdk', '3.0')
 gi.require_version('Gtk', '3.0')
-from gi.repository import Gdk
-from gi.repository import Gtk
-import pygame
-import sugargame
-import sugargame.canvas
-from sugar3 import mime
-from sugar3.activity import activity
-from sugar3.graphics.toolbarbox import ToolbarBox
-from sugar3.activity.widgets import ActivityToolbarButton
-from sugar3.activity.widgets import StopButton
-from sugar3.graphics.toolbutton import ToolButton
-from sugar3.graphics.objectchooser import ObjectChooser
-from sugar3.datastore import datastore
-from gettext import gettext as _
-
-import puntillism
 
 
 class Activity(activity.Activity):
@@ -58,9 +57,11 @@ class Activity(activity.Activity):
 
         self.build_toolbar()
 
-        self._pygamecanvas = sugargame.canvas.PygameCanvas(self,
-            main=self.actividad.run,
-            modules=[pygame.display])
+        self._pygamecanvas = \
+            sugargame.canvas.PygameCanvas(
+                self,
+                main=self.actividad.run,
+                modules=[pygame.display])
 
         self.set_canvas(self._pygamecanvas)
         self._pygamecanvas.grab_focus()
@@ -152,22 +153,25 @@ class Activity(activity.Activity):
         self.actividad.poner_radio2(self.radio_dos)
 
     def _savebutton_cb(self, button):
-        pygame.event.post(pygame.event.Event(pygame.USEREVENT, action='savebutton'))
+        pygame.event.post(pygame.event.Event(
+            pygame.USEREVENT, action='savebutton'))
 
     def save_image(self, image):
         journalobj = datastore.create()
         journalobj.metadata['title'] = _('Pointillism')
         journalobj.metadata['mime_type'] = 'image/jpeg'
 
-        file_path = os.path.join(os.environ['SUGAR_ACTIVITY_ROOT'], 'data', 'pointillism.jpg')
+        file_path = os.path.join(
+            os.environ['SUGAR_ACTIVITY_ROOT'], 'data', 'pointillism.jpg')
 
-        pygame.image.save(image,file_path)
+        pygame.image.save(image, file_path)
         journalobj.set_file_path(file_path)
         datastore.write(journalobj)
         journalobj.destroy()
 
     def open_image(self, button):
-        pygame.event.post(pygame.event.Event(pygame.USEREVENT, action='openbutton'))
+        pygame.event.post(pygame.event.Event(
+            pygame.USEREVENT, action='openbutton'))
 
     def choose_image_from_journal_cb(self):
         ''' Create a chooser for image objects '''
@@ -175,7 +179,8 @@ class Activity(activity.Activity):
         ##
         self.chooser = None
         try:
-            self.chooser = ObjectChooser(parent=self, what_filter=mime.GENERIC_TYPE_IMAGE)
+            self.chooser = ObjectChooser(
+                parent=self, what_filter=mime.GENERIC_TYPE_IMAGE)
         except TypeError:
             self.chooser = ObjectChooser(
                 None, self,
@@ -196,7 +201,5 @@ class Activity(activity.Activity):
         self.file_path_temp = self.choose_image_from_journal_cb()
         return self.file_path_temp
 
-
     def get_preview(self):
         return self._pygamecanvas.get_preview()
-

--- a/activity.py
+++ b/activity.py
@@ -43,6 +43,7 @@ from gettext import gettext as _
 
 import puntillism
 
+
 class Activity(activity.Activity):
 
     def __init__(self, handle):
@@ -91,7 +92,8 @@ class Activity(activity.Activity):
         self.cradio1.set_range(1, 20)
         self.cradio1.set_increments(1, 2)
         self.cradio1.props.value = self.radio_uno
-        self.cradio1_handler = self.cradio1.connect('notify::value', self.cradio1_valor)
+        self.cradio1_handler = self.cradio1.connect(
+            'notify::value', self.cradio1_valor)
         item2.add(self.cradio1)
         barra.insert(item2, 3)
 
@@ -107,13 +109,14 @@ class Activity(activity.Activity):
         self.cradio2.set_range(1, 20)
         self.cradio2.set_increments(1, 2)
         self.cradio2.props.value = self.radio_dos
-        self.cradio2_handler = self.cradio2.connect('notify::value', self.cradio2_valor)
+        self.cradio2_handler = self.cradio2.connect(
+            'notify::value', self.cradio2_valor)
         item4.add(self.cradio2)
         barra.insert(item4, 5)
         separator1 = Gtk.SeparatorToolItem()
         separator1.props.draw = True
         separator1.set_expand(False)
-        barra.insert(separator1,6)
+        barra.insert(separator1, 6)
 
         save_button = ToolButton('filesave')
         save_button.set_tooltip(_('Save Image'))
@@ -130,7 +133,7 @@ class Activity(activity.Activity):
         separator2 = Gtk.SeparatorToolItem()
         separator2.props.draw = False
         separator2.set_expand(True)
-        barra.insert(separator2,9)
+        barra.insert(separator2, 9)
 
         stop_button = StopButton(self)
         stop_button.props.accelerator = '<Ctrl>q'
@@ -148,12 +151,12 @@ class Activity(activity.Activity):
         self.radio_dos = int(radio.props.value)
         self.actividad.poner_radio2(self.radio_dos)
 
-    def _savebutton_cb(self,button):
+    def _savebutton_cb(self, button):
         pygame.event.post(pygame.event.Event(pygame.USEREVENT, action='savebutton'))
-    
-    def save_image(self,image):
+
+    def save_image(self, image):
         journalobj = datastore.create()
-        journalobj.metadata['title'] = _('Pointillism')
+        journalobj.metadata['title'] = ('Pointillism')
         journalobj.metadata['mime_type'] = 'image/jpeg'
 
         file_path = os.path.join(os.environ['SUGAR_ACTIVITY_ROOT'], 'data', 'pointillism.jpg')
@@ -162,12 +165,12 @@ class Activity(activity.Activity):
         journalobj.set_file_path(file_path)
         datastore.write(journalobj)
         journalobj.destroy()
-    
-    def open_image(self,button):
+
+    def open_image(self, button):
         pygame.event.post(pygame.event.Event(pygame.USEREVENT, action='openbutton'))
 
     def choose_image_from_journal_cb(self):
-        
+
         ''' Create a chooser for image objects '''
         self.image_id = None
         chooser = ObjectChooser(what_filter=mime.GENERIC_TYPE_IMAGE)

--- a/activity.py
+++ b/activity.py
@@ -172,16 +172,17 @@ class Activity(activity.Activity):
     def choose_image_from_journal_cb(self):
         ''' Create a chooser for image objects '''
         self.image_id = None
-        chooser = ObjectChooser(what_filter=mime.GENERIC_TYPE_IMAGE)
-        result = chooser.run()
+        self.chooser = ObjectChooser(what_filter=mime.GENERIC_TYPE_IMAGE)
+        result = self.chooser.run()
         if result == Gtk.ResponseType.ACCEPT:
-            jobject = chooser.get_selected_object()
-            self.image_id = str(jobject._object_id)
-            self.image_file_path = str(jobject.get_file_path())
-            puntillism.Puntillism.file_path = self.image_file_path
-            jobject.destroy()
-            chooser.destroy()
-            return self.image_file_path
+            self.jobject = self.chooser.get_selected_object()
+            self.image_id = str(self.jobject._object_id)
+            return str(self.jobject.get_file_path())
+        else:
+            self.jobject.destroy()
+            self.chooser.destroy()
+            return None
+
 
     def get_preview(self):
         return self._pygamecanvas.get_preview()

--- a/activity.py
+++ b/activity.py
@@ -110,10 +110,6 @@ class Activity(activity.Activity):
         self.cradio2_handler = self.cradio2.connect('notify::value', self.cradio2_valor)
         item4.add(self.cradio2)
         barra.insert(item4, 5)
-
-
-        
-
         separator1 = Gtk.SeparatorToolItem()
         separator1.props.draw = True
         separator1.set_expand(False)
@@ -142,7 +138,6 @@ class Activity(activity.Activity):
         stop_button.show()
 
         self.set_toolbar_box(toolbar_box)
-
         toolbar_box.show_all()
 
     def cradio1_valor(self, radio, value):
@@ -156,7 +151,6 @@ class Activity(activity.Activity):
     def _savebutton_cb(self,button):
         pygame.event.post(pygame.event.Event(pygame.USEREVENT, action='savebutton'))
     
-
     def save_image(self,image):
         journalobj = datastore.create()
         journalobj.metadata['title'] = _('Pointillism')
@@ -167,7 +161,6 @@ class Activity(activity.Activity):
         pygame.image.save(image,file_path)
         journalobj.set_file_path(file_path)
         datastore.write(journalobj)
-
         journalobj.destroy()
     
     def open_image(self,button):
@@ -176,7 +169,6 @@ class Activity(activity.Activity):
     def choose_image_from_journal_cb(self):
         
         ''' Create a chooser for image objects '''
-
         self.image_id = None
         chooser = ObjectChooser(what_filter=mime.GENERIC_TYPE_IMAGE)
         result = chooser.run()

--- a/activity.py
+++ b/activity.py
@@ -50,7 +50,7 @@ class Activity(activity.Activity):
         activity.Activity.__init__(self, handle)
 
         self.max_participants = 1
-
+        self.file_path_temp = None
         self.radio_uno = 2
         self.radio_dos = 12
 
@@ -172,14 +172,29 @@ class Activity(activity.Activity):
     def choose_image_from_journal_cb(self):
         ''' Create a chooser for image objects '''
         self.image_id = None
-        self.chooser = ObjectChooser(what_filter=mime.GENERIC_TYPE_IMAGE)
-        result = self.chooser.run()
-        if result == Gtk.ResponseType.ACCEPT:
-            self.jobject = self.chooser.get_selected_object()
-            self.image_id = str(self.jobject._object_id)
-            return str(self.jobject.get_file_path())
-        else:
-            return None
+        ##
+        self.chooser = None
+        try:
+            self.chooser = ObjectChooser(parent=self, what_filter=mime.GENERIC_TYPE_IMAGE)
+        except TypeError:
+            self.chooser = ObjectChooser(
+                None, self,
+                Gtk.DialogFlags.MODAL | Gtk.DialogFlags.DESTROY_WITH_PARENT)
+        if self.chooser is not None:
+            try:
+                result = self.chooser.run()
+                if result == Gtk.ResponseType.ACCEPT:
+                    dsobject = self.chooser.get_selected_object()
+                    self.file_path_temp = str(dsobject.get_file_path())[:]
+
+            finally:
+                self.chooser.destroy()
+                del self.chooser
+                return self.file_path_temp
+
+    def return_image_to_pygame(self):
+        self.file_path_temp = self.choose_image_from_journal_cb()
+        return self.file_path_temp
 
 
     def get_preview(self):

--- a/activity.py
+++ b/activity.py
@@ -31,11 +31,13 @@ from gi.repository import Gtk
 import pygame
 import sugargame
 import sugargame.canvas
+from sugar3 import mime
 from sugar3.activity import activity
 from sugar3.graphics.toolbarbox import ToolbarBox
 from sugar3.activity.widgets import ActivityToolbarButton
 from sugar3.activity.widgets import StopButton
 from sugar3.graphics.toolbutton import ToolButton
+from sugar3.graphics.objectchooser import ObjectChooser
 from sugar3.datastore import datastore
 from gettext import gettext as _
 
@@ -109,6 +111,9 @@ class Activity(activity.Activity):
         item4.add(self.cradio2)
         barra.insert(item4, 5)
 
+
+        
+
         separator1 = Gtk.SeparatorToolItem()
         separator1.props.draw = True
         separator1.set_expand(False)
@@ -120,14 +125,20 @@ class Activity(activity.Activity):
         barra.insert(save_button, 7)
         save_button.show()
 
+        open_button = ToolButton('fileopen')
+        open_button.set_tooltip(_('Open Image'))
+        open_button.connect('clicked', self.open_image)
+        barra.insert(open_button, 8)
+        open_button.show()
+
         separator2 = Gtk.SeparatorToolItem()
         separator2.props.draw = False
         separator2.set_expand(True)
-        barra.insert(separator2,8)
+        barra.insert(separator2,9)
 
         stop_button = StopButton(self)
         stop_button.props.accelerator = '<Ctrl>q'
-        barra.insert(stop_button, 9)
+        barra.insert(stop_button, 10)
         stop_button.show()
 
         self.set_toolbar_box(toolbar_box)
@@ -144,6 +155,7 @@ class Activity(activity.Activity):
 
     def _savebutton_cb(self,button):
         pygame.event.post(pygame.event.Event(pygame.USEREVENT, action='savebutton'))
+    
 
     def save_image(self,image):
         journalobj = datastore.create()
@@ -157,6 +169,24 @@ class Activity(activity.Activity):
         datastore.write(journalobj)
 
         journalobj.destroy()
+    
+    def open_image(self,button):
+        pygame.event.post(pygame.event.Event(pygame.USEREVENT, action='openbutton'))
+
+    def choose_image_from_journal_cb(self):
+        
+        ''' Create a chooser for image objects '''
+
+        self.image_id = None
+        chooser = ObjectChooser(what_filter=mime.GENERIC_TYPE_IMAGE)
+        result = chooser.run()
+        if result == Gtk.ResponseType.ACCEPT:
+            jobject = chooser.get_selected_object()
+            self.image_id = str(jobject._object_id)
+        print(str(jobject.get_file_path()))
+        puntillism.Puntillism.file_path = str(jobject.get_file_path())
+        return str(jobject.get_file_path())
 
     def get_preview(self):
         return self._pygamecanvas.get_preview()
+

--- a/activity.py
+++ b/activity.py
@@ -170,7 +170,6 @@ class Activity(activity.Activity):
         pygame.event.post(pygame.event.Event(pygame.USEREVENT, action='openbutton'))
 
     def choose_image_from_journal_cb(self):
-
         ''' Create a chooser for image objects '''
         self.image_id = None
         chooser = ObjectChooser(what_filter=mime.GENERIC_TYPE_IMAGE)
@@ -178,12 +177,11 @@ class Activity(activity.Activity):
         if result == Gtk.ResponseType.ACCEPT:
             jobject = chooser.get_selected_object()
             self.image_id = str(jobject._object_id)
-        try:
-            print(str(jobject.get_file_path()))
-            puntillism.Puntillism.file_path = str(jobject.get_file_path())
-            return str(jobject.get_file_path())
-        except (UnboundLocalError, NameError):
-            return None
+            self.image_file_path = str(jobject.get_file_path())
+            puntillism.Puntillism.file_path = self.image_file_path
+            jobject.destroy()
+            chooser.destroy()
+            return self.image_file_path
 
     def get_preview(self):
         return self._pygamecanvas.get_preview()

--- a/activity.py
+++ b/activity.py
@@ -179,8 +179,6 @@ class Activity(activity.Activity):
             self.image_id = str(self.jobject._object_id)
             return str(self.jobject.get_file_path())
         else:
-            self.jobject.destroy()
-            self.chooser.destroy()
             return None
 
 

--- a/po/Pointillism.pot
+++ b/po/Pointillism.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-12-20 21:04+0300\n"
+"POT-Creation-Date: 2019-12-21 20:12+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -41,10 +41,14 @@ msgstr ""
 msgid "Open Image"
 msgstr ""
 
-#: puntillism.py:103
+#: puntillism.py:106
 msgid "Camera not found"
 msgstr ""
 
-#: puntillism.py:203
+#: puntillism.py:175
+msgid "Loading Image Selector..."
+msgstr ""
+
+#: puntillism.py:206
 msgid "Click the Load Image Button"
 msgstr ""

--- a/po/Pointillism.pot
+++ b/po/Pointillism.pot
@@ -8,32 +8,39 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2012-09-27 14:56-0400\n"
+"POT-Creation-Date: 2019-12-19 18:07+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=CHARSET\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#. TRANS: "name" option from activity.info file
-#: activity.py:138
+#: activity/activity.info:2
 msgid "Pointillism"
 msgstr ""
 
-#. TRANS: "summary" option from activity.info file
-#. TRANS: "description" option from activity.info file
-msgid "Creates a pointillist image from the camera captures"
+#: activity/activity.info:3
+msgid "Create a pointillist image from the camera"
 msgstr ""
 
-#: activity.py:72
+#: activity.py:83
 msgid "Circles between"
 msgstr ""
 
-#: activity.py:87
+#: activity.py:102
 msgid "and"
 msgstr ""
 
-#: activity.py:106
+#: activity.py:122
 msgid "Save Image"
+msgstr ""
+
+#: activity.py:128
+msgid "Open Image"
+msgstr ""
+
+#: puntillism.py:104
+msgid "Camera not found"
 msgstr ""

--- a/po/Pointillism.pot
+++ b/po/Pointillism.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-12-19 18:07+0300\n"
+"POT-Creation-Date: 2019-12-20 21:04+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Content-Type: text/plain; charset=CHARSET\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: activity/activity.info:2
+#: activity/activity.info:2 activity.py:159
 msgid "Pointillism"
 msgstr ""
 
@@ -41,6 +41,10 @@ msgstr ""
 msgid "Open Image"
 msgstr ""
 
-#: puntillism.py:104
+#: puntillism.py:103
 msgid "Camera not found"
+msgstr ""
+
+#: puntillism.py:203
+msgid "Click the Load Image Button"
 msgstr ""

--- a/puntillism.py
+++ b/puntillism.py
@@ -98,10 +98,8 @@ class Puntillism():
             self.read_events(events, screen)
 
         # define some colors for not cam found
-        green = (0, 255, 0)
-        blue0 = (0, 0, 128)
         font = pygame.font.Font('freesansbold.ttf', 32)
-        text = font.render(_('Camera not found'), True, green, blue0)
+        text = font.render(_('Camera not found'), True, (255, 255, 255), (0, 0, 0))
         text_frame = text.get_rect()
         text_frame.center = (x_s // 2, y_s // 2)
 
@@ -177,6 +175,7 @@ class Puntillism():
                                 # The jobject either didn't return anything
                                 # Some error might have happened, while selecting the image
                                 # Just leave it with the current view, if nothings gone wrong
+                                pygame.display.update()
                                 pass
 
                         except Exception as e:

--- a/puntillism.py
+++ b/puntillism.py
@@ -206,7 +206,7 @@ class Puntillism():
 
         while self.load_image_loop:
 
-            if self.file_path is not None:
+            if (self.file_path is not None) and (self.file_path != "NULL"):
                 cad = pygame.image.load(self.file_path).convert()
                 cad = pygame.transform.scale(cad, (640, 480))
                 rect = []

--- a/puntillism.py
+++ b/puntillism.py
@@ -28,6 +28,10 @@ import gi
 gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk
 import random
+from sugar3 import mime
+from sugar3.graphics.objectchooser import ObjectChooser
+from sugar3.datastore import datastore
+
 try:
     import pygame
     from pygame import camera
@@ -38,6 +42,8 @@ class Puntillism():
 
     def __init__(self, parent):
         self.parent = parent
+        #global file_path
+        self.file_path = "NULL"
         #logging.basicConfig()
 
     def poner_radio1(self, radio):
@@ -45,6 +51,19 @@ class Puntillism():
 
     def poner_radio2(self, radio):
         self.radio2 = radio
+
+    def _choose_image_from_journal_cb(self, button):
+        ''' Create a chooser for image objects '''
+
+        self.image_id = None
+        chooser = ObjectChooser(what_filter=mime.GENERIC_TYPE_IMAGE)
+        result = chooser.run()
+        if result == Gtk.ResponseType.ACCEPT:
+            jobject = chooser.get_selected_object()
+            self.image_id = str(jobject._object_id)
+        print(str(jobject.get_file_path()))
+        puntillism.Puntillism.file_path = str(jobject.get_file_path())
+        return str(jobject.get_file_path())
 
     def run(self):
         #size = (1200,900)
@@ -55,6 +74,8 @@ class Puntillism():
         self.radio1 = 2
         self.radio2 = 12
 
+        camNotFound_holder = False  # create a local variable to check camera not found and in loop
+
         screen = pygame.display.get_surface()
         screen.fill((0,0,0))
         pygame.display.flip()
@@ -63,9 +84,22 @@ class Puntillism():
         x_s, y_s = screen.get_size()
 
         clock = pygame.time.Clock()
+<<<<<<< HEAD
+        running = True
+        camfound = False
+        try:
+            cam = camera.Camera("/dev/video0", (640, 480), "RGB")
+            cam.start()
+            camfound = True
+            
+        except SystemError:
+            running = False
+            camfound = False
+=======
 
         cam = camera.Camera("/dev/video0", (640, 480), "RGB")
         cam.start()
+>>>>>>> 74965ff70703843755c60a96533e68ebe61fdcde
         try:
             cam.set_controls(hflip=True)
         except SystemError:
@@ -73,10 +107,101 @@ class Puntillism():
 
         cap = pygame.surface.Surface((640, 480), 0, screen)
         frames = 0
-        running = True
+        
+        if not camfound:
+            # define some colors for not cam found
+            green0 = (0, 255, 0) 
+            white0 = (255, 255, 255) 
+            blue0 = (0, 0, 128) 
+            font = pygame.font.Font('freesansbold.ttf', 16)
+            text = font.render('uh-oh! You doesn\'t seem to have a Camera. Use Open Image option', True, green0, blue0) 
+            textRect = text.get_rect() 
+            textRect.center = (x_s // 2, y_s // 2)
+            print("LOG: No /dev/video0 found")
+            camNotFound_holder = True
+            screen.fill((0,0,0))
+            pygame.display.update() 
+        
+        while (not camfound) and camNotFound_holder:
+    
+            # print(self.file_path) Uncomment this line to know file path
+            # For debuggers only
+            
+            if self.file_path != "NULL":
+                  
+                cad = pygame.image.load(self.file_path).convert_alpha()
+                cad = pygame.transform.scale(cad, (640,480))
+                rect = []
+                
+                for z in range(max(20, int(frames)*10)):
+                    x = random.random()
+                    y = random.random()
+                    if self.radio1 > self.radio2:
+                        aux = self.radio2
+                        self.radio2 = self.radio1
+                        self.radio1 = aux
+                    elif self.radio1 == self.radio2:
+                        self.radio2 = self.radio2 + 1
+                    num = random.randrange(self.radio1, self.radio2, 1)
+                    
+                    rect.append(pygame.draw.circle(screen, cad.get_at((int(x * 640), int(y * 480))), (int(x * x_s), int(y * y_s)), num, 0))
+                pygame.display.update(rect)
+
+            else:
+                
+                screen.fill((0,0,0)) 
+                screen.blit(text, textRect) 
+                pygame.display.update()
+            
+            clock.tick()
+            frames = clock.get_fps()
+
+            #GTK events
+            while Gtk.events_pending():
+                Gtk.main_iteration()
+
+            events = pygame.event.get()
+            for event in events:
+                #log.debug( "Event: %s", event )
+                if event.type == pygame.QUIT:
+                    camNotFound_holder = False
+                    
+                elif event.type == pygame.VIDEORESIZE:
+                    pygame.display.set_mode(event.size, pygame.RESIZABLE)
+                elif event.type == pygame.KEYDOWN:
+                    if event.key == pygame.K_ESCAPE:
+                        
+                        camNotFound_holder = False
+                    elif event.key == pygame.K_s:
+                        self.parent.save_image(screen)
+                elif event.type == pygame.USEREVENT:
+                    if hasattr(event,'action'):
+                        if event.action == 'savebutton':
+                            self.parent.save_image(screen)
+                        if event.action == 'openbutton':
+                            #global file_path
+                            print("OPEN")
+                            self.file_path = self.parent.choose_image_from_journal_cb()
+                            # print(">.... ", self.file_path)
+                            print("LOG: File Loaded Successfully")
+                            screen.fill((0,0,0)) 
+                            
+                            
+
+        # after checking if camera exists, cam is not accepted if /dev/video0 > null
+        # Usually null gives a black screen, before initiating the display
+        # A black screen is filled 
+        if running:
+            screen.fill((0,0,0))
+            pygame.display.update()
+
         while running:
             cap = cam.get_image(cap)
+            # Command for loading image cad = pygame.image.load("xx.png").convert_alpha()
+            # print(cap, type(cap), cad, type(cad), "CAAAAAAAAAAAAAAAAAAAAAAAAAAP")
             rect = []
+            
+
             for z in range(max(20, int(frames)*10)):
                 x = random.random()
                 y = random.random()
@@ -116,4 +241,5 @@ class Puntillism():
                         if event.action == 'savebutton':
                             self.parent.save_image(screen)
             #pygame.display.flip()
+
 

--- a/puntillism.py
+++ b/puntillism.py
@@ -53,7 +53,7 @@ class Puntillism():
         self.radio2 = 12
 
         # create a local variable to check camera not found and in loop
-        self.camNotFound_holder = False
+        self.load_image_loop = False
 
         screen = pygame.display.get_surface()
         screen.fill((0, 0, 0))
@@ -64,14 +64,14 @@ class Puntillism():
 
         clock = pygame.time.Clock()
         self.running = True
-        self.camfound = False
+        self.has_camera = False
         try:
             cam = camera.Camera("/dev/video0", (640, 480), "RGB")
             cam.start()
-            self.camfound = True
+            self.has_camera = True
         except SystemError:
             self.running = False
-            self.camfound = False
+            self.has_camera = False
 
         try:
             cam.set_controls(hflip=True)
@@ -98,16 +98,16 @@ class Puntillism():
             self.read_events(events, screen)
 
         # define some colors for not cam found
-        green0 = (0, 255, 0)
+        green = (0, 255, 0)
         blue0 = (0, 0, 128)
         font = pygame.font.Font('freesansbold.ttf', 32)
-        text = font.render(_('Camera not found'), True, green0, blue0)
-        textRect = text.get_rect()
-        textRect.center = (x_s // 2, y_s // 2)
+        text = font.render(_('Camera not found'), True, green, blue0)
+        text_frame = text.get_rect()
+        text_frame.center = (x_s // 2, y_s // 2)
 
-        if not self.camfound:
+        if not self.has_camera:
             print("LOG: No /dev/video0 found")
-            self.camNotFound_holder = True
+            self.load_image_loop = True
 
         # after checking if camera exists, cam is not accepted
         # if /dev/video0 > null ually null gives a black screen,
@@ -115,9 +115,9 @@ class Puntillism():
         screen.fill((0, 0, 0))
         pygame.display.update()
 
-        if self.camNotFound_holder:
-            self.camNotFoundHandler(screen, frames,
-                                    x_s, y_s, clock, text, textRect)
+        if self.load_image_loop:
+            self.image_load_handler(screen, frames,
+                                    x_s, y_s, clock, text, text_frame)
 
     def create_rect(self, cad, rect, frames, clock, screen, x_size, y_size):
         for z in range(max(20, int(frames)*10)):
@@ -144,7 +144,7 @@ class Puntillism():
 
             if event.type == pygame.QUIT:
                 self.running = False
-                self.camNotFound_holder = False
+                self.load_image_loop = False
 
             elif event.type == pygame.VIDEORESIZE:
                 pygame.display.set_mode(event.size, pygame.RESIZABLE)
@@ -153,7 +153,7 @@ class Puntillism():
 
                 if event.key == pygame.K_ESCAPE:
                     self.running = False
-                    self.camNotFound_holder = False
+                    self.load_image_loop = False
 
                 elif event.key == pygame.K_s:
                     self.parent.save_image(screen)
@@ -170,10 +170,10 @@ class Puntillism():
                         screen.fill((0, 0, 0))
                         pygame.display.update()
                         self.running = False
-                        self.camNotFound_holder = True
+                        self.load_image_loop = True
 
-    def camNotFoundHandler(self, screen, frames, x_s, y_s, clock, text, textRect):
-        while self.camNotFound_holder:
+    def image_load_handler(self, screen, frames, x_s, y_s, clock, text, text_frame):
+        while self.load_image_loop:
 
             if self.file_path != "NULL":
                 cad = pygame.image.load(self.file_path).convert_alpha()
@@ -183,7 +183,7 @@ class Puntillism():
 
             else:
                 screen.fill((0, 0, 0))
-                screen.blit(text, textRect)
+                screen.blit(text, text_frame)
                 pygame.display.update()
 
             # GTK events

--- a/puntillism.py
+++ b/puntillism.py
@@ -22,8 +22,6 @@
 # Alan Aguiar <alanjas@gmail.com>
 # Nirav Patel <sugarlabs@spongezone.net>
 
-import os
-import sys
 import gi
 gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk
@@ -33,6 +31,7 @@ try:
     from pygame import camera
 except (ImportError, ModuleNotFoundError):
     print('Error in import Pygame. This activity requires Pygame 1.9')
+
 
 class Puntillism():
 
@@ -47,16 +46,16 @@ class Puntillism():
         self.radio2 = radio
 
     def run(self):
-        #size = (1200,900)
         pygame.init()
         pygame.camera.init()
-        #camera.init()
         self.radio1 = 2
         self.radio2 = 12
-        self.camNotFound_holder = False  # create a local variable to check camera not found and in loop
+
+        # create a local variable to check camera not found and in loop
+        self.camNotFound_holder = False
 
         screen = pygame.display.get_surface()
-        screen.fill((0,0,0))
+        screen.fill((0, 0, 0))
         pygame.display.flip()
 
         x_s, y_s = (1200, 900)
@@ -72,7 +71,7 @@ class Puntillism():
         except SystemError:
             self.running = False
             self.camfound = False
-            
+
         try:
             cam.set_controls(hflip=True)
         except SystemError:
@@ -80,44 +79,44 @@ class Puntillism():
 
         cap = pygame.surface.Surface((640, 480), 0, screen)
         frames = 0
-        
+
         if self.running:
-            screen.fill((0,0,0))
+            screen.fill((0, 0, 0))
             pygame.display.update()
 
         while self.running:
             cap = cam.get_image(cap)
             rect = []
-            self.create_rect(cap, rect, frames, clock,screen,x_s, y_s)
+            self.create_rect(cap, rect, frames, clock, screen, x_s, y_s)
 
-            #GTK events
+            # GTK events
             while Gtk.events_pending():
                 Gtk.main_iteration()
 
             events = pygame.event.get()
-            self.read_events(events,screen)
+            self.read_events(events, screen)
 
         # define some colors for not cam found
-        green0 = (0, 255, 0) 
-        white0 = (255, 255, 255) 
-        blue0 = (0, 0, 128) 
+        green0 = (0, 255, 0)
+        blue0 = (0, 0, 128)
         font = pygame.font.Font('freesansbold.ttf', 32)
-        text = font.render('Camera not found', True, green0, blue0) 
-        textRect = text.get_rect() 
+        text = font.render('Camera not found', True, green0, blue0)
+        textRect = text.get_rect()
         textRect.center = (x_s // 2, y_s // 2)
 
         if not self.camfound:
             print("LOG: No /dev/video0 found")
             self.camNotFound_holder = True
-        
-        # after checking if camera exists, cam is not accepted if /dev/video0 > null
-        # Usually null gives a black screen, before initiating the display
-        # A black screen is filled 
-        screen.fill((0,0,0))
+
+        # after checking if camera exists, cam is not accepted
+        # if /dev/video0 > null ually null gives a black screen,
+        # before initiating the display, A black screen is filled
+        screen.fill((0, 0, 0))
         pygame.display.update()
 
         if self.camNotFound_holder:
-            self.camNotFoundHandler(screen,frames, x_s, y_s, clock, text, textRect)
+            self.camNotFoundHandler(screen, frames,
+                                    x_s, y_s, clock, text, textRect)
 
     def create_rect(self, cad, rect, frames, clock, screen, x_size, y_size):
         for z in range(max(20, int(frames)*10)):
@@ -130,19 +129,22 @@ class Puntillism():
             elif self.radio1 == self.radio2:
                 self.radio2 = self.radio2 + 1
             num = random.randrange(self.radio1, self.radio2, 1)
-            
-            rect.append(pygame.draw.circle(screen, cad.get_at((int(x * 640), int(y * 480))), (int(x * x_size), int(y * y_size)), num, 0))
+            rect.append(pygame.draw.circle(
+                screen,
+                cad.get_at((int(x * 640), int(y * 480))),
+                (int(x * x_size), int(y * y_size)),
+                num, 0))
         pygame.display.update(rect)
         clock.tick()
         frames = clock.get_fps()
-    
+
     def read_events(self, events, screen):
         for event in events:
-            
+
             if event.type == pygame.QUIT:
                 self.running = False
                 self.camNotFound_holder = False
-                
+
             elif event.type == pygame.VIDEORESIZE:
                 pygame.display.set_mode(event.size, pygame.RESIZABLE)
 
@@ -151,46 +153,41 @@ class Puntillism():
                 if event.key == pygame.K_ESCAPE:
                     self.running = False
                     self.camNotFound_holder = False
-    
+
                 elif event.key == pygame.K_s:
                     self.parent.save_image(screen)
 
             elif event.type == pygame.USEREVENT:
 
-                if hasattr(event,'action'):
+                if hasattr(event, 'action'):
 
                     if event.action == 'savebutton':
                         self.parent.save_image(screen)
 
                     if event.action == 'openbutton':
                         self.file_path = self.parent.choose_image_from_journal_cb()
-                        screen.fill((0,0,0)) 
+                        screen.fill((0, 0, 0))
                         pygame.display.update()
                         self.running = False
                         self.camNotFound_holder = True
-                        
 
     def camNotFoundHandler(self, screen, frames, x_s, y_s, clock, text, textRect):
         while self.camNotFound_holder:
-            
-            if self.file_path != "NULL":           
+
+            if self.file_path != "NULL":
                 cad = pygame.image.load(self.file_path).convert_alpha()
-                cad = pygame.transform.scale(cad, (640,480))
+                cad = pygame.transform.scale(cad, (640, 480))
                 rect = []
-                self.create_rect(cad, rect, frames, clock,screen,x_s, y_s)
+                self.create_rect(cad, rect, frames, clock, screen, x_s, y_s)
 
             else:
-                screen.fill((0,0,0)) 
-                screen.blit(text, textRect) 
+                screen.fill((0, 0, 0))
+                screen.blit(text, textRect)
                 pygame.display.update()
 
-            #GTK events
+            # GTK events
             while Gtk.events_pending():
                 Gtk.main_iteration()
 
             events = pygame.event.get()
             self.read_events(events, screen)
-                        
-                        
-
-                            

--- a/puntillism.py
+++ b/puntillism.py
@@ -22,6 +22,7 @@
 # Alan Aguiar <alanjas@gmail.com>
 # Nirav Patel <sugarlabs@spongezone.net>
 
+import sys
 import gi
 gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk
@@ -117,6 +118,14 @@ class Puntillism():
             self.image_load_handler(screen, frames,
                                     x_s, y_s, clock, text, text_frame)
 
+        # Destroy image load events
+        try:
+            self.parent.jobject.destroy()
+            self.parent.chooser.destroy()
+        except Exception as e:
+            print("ERROR {}".format(e))
+            pass
+
     def create_rect(self, cad, rect, frames, clock, screen, x_size, y_size):
         for z in range(max(20, int(frames)*10)):
             x = random.random()
@@ -133,6 +142,7 @@ class Puntillism():
                 cad.get_at((int(x * 640), int(y * 480))),
                 (int(x * x_size), int(y * y_size)),
                 num, 0))
+        pygame.display.update()
         pygame.display.update(rect)
         clock.tick()
         frames = clock.get_fps()
@@ -152,7 +162,7 @@ class Puntillism():
                 if event.key == pygame.K_ESCAPE:
                     self.running = False
                     self.load_image_loop = False
-
+                    
                 elif event.key == pygame.K_s:
                     self.parent.save_image(screen)
 
@@ -183,10 +193,14 @@ class Puntillism():
                             self.running = True
 
     def image_load_handler(self, screen, frames, x_s, y_s, clock, text, text_frame):
+        screen.fill((0, 0, 0))
+        pygame.display.update()
+
         while self.load_image_loop:
 
-            if self.file_path != "NULL":
-                cad = pygame.image.load(self.file_path).convert_alpha()
+            if self.file_path is not None:
+
+                cad = pygame.image.load(self.file_path).convert()
                 cad = pygame.transform.scale(cad, (640, 480))
                 rect = []
                 self.create_rect(cad, rect, frames, clock, screen, x_s, y_s)

--- a/puntillism.py
+++ b/puntillism.py
@@ -22,17 +22,16 @@
 # Alan Aguiar <alanjas@gmail.com>
 # Nirav Patel <sugarlabs@spongezone.net>
 
-import sys
+from gettext import gettext as _
+import random
+from gi.repository import Gtk
 import gi
 gi.require_version('Gtk', '3.0')
-from gi.repository import Gtk
-import random
 try:
     import pygame
     from pygame import camera
 except (ImportError, ModuleNotFoundError):
     print('Error in import Pygame. This activity requires Pygame 1.9')
-from gettext import gettext as _
 
 
 class Puntillism():
@@ -58,7 +57,7 @@ class Puntillism():
 
         # Declare a font
         font = pygame.font.Font('freesansbold.ttf', 32)
-        
+
         screen = pygame.display.get_surface()
         screen.fill((0, 0, 0))
         pygame.display.flip()
@@ -102,9 +101,8 @@ class Puntillism():
             self.read_events(events, screen, font, x_s, y_s)
 
         # define some colors for not cam found
-        
-        message = _('Camera not found')
 
+        message = _('Camera not found')
 
         if not self.has_camera:
             print("LOG: No /dev/video0 found")
@@ -119,7 +117,6 @@ class Puntillism():
         if self.load_image_loop:
             self.image_load_handler(screen, frames,
                                     x_s, y_s, clock, message, font)
-
 
     def create_rect(self, cad, rect, frames, clock, screen, x_size, y_size):
         for z in range(max(20, int(frames)*10)):
@@ -171,8 +168,11 @@ class Puntillism():
                     if event.action == 'openbutton':
 
                         # ObjectChooser might take a few seconds to load
-                        # A text message might be needed to reflect the loading ObjectChooser
-                        text = font.render(_("Loading Image Selector..."), True, (255, 255, 255), (0, 0, 0))
+                        # A text message might be needed to reflect
+                        # the loading ObjectChooser
+                        text = font.render(
+                            ("Loading Image Selector..."),
+                            True, (255, 255, 255), (0, 0, 0))
                         text_frame = text.get_rect()
                         screen.fill((0, 0, 0))
                         screen.blit(text, text_frame)
@@ -188,13 +188,15 @@ class Puntillism():
                             self.load_image_loop = True
                         else:
                             # The jobject either didn't return anything
-                            # Some error might have happened, while selecting the image
-                            # Just leave it with the current view, if nothings gone wrong
+                            # Some error might have happened,
+                            # while selecting the image
+                            # Just leave it with the current view,
+                            # if nothings gone wrong
                             pygame.display.update()
                             pass
 
-
-    def image_load_handler(self, screen, frames, x_s, y_s, clock, message, font):
+    def image_load_handler(
+            self, screen, frames, x_s, y_s, clock, message, font):
         screen.fill((0, 0, 0))
         pygame.display.update()
 
@@ -203,7 +205,8 @@ class Puntillism():
             text_frame = text.get_rect()
             text_frame.center = (x_s // 2, y_s // 2)
         else:
-            text = font.render(_("Click the Load Image Button"), True, (255, 255, 255), (0, 0, 0))
+            text = font.render(_("Click the Load Image Button"),
+                               True, (255, 255, 255), (0, 0, 0))
             text_frame = text.get_rect()
             text_frame.center = (x_s // 2, y_s // 2)
 

--- a/puntillism.py
+++ b/puntillism.py
@@ -28,7 +28,6 @@ import gi
 gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk
 import random
-
 try:
     import pygame
     from pygame import camera
@@ -39,9 +38,7 @@ class Puntillism():
 
     def __init__(self, parent):
         self.parent = parent
-        #global file_path
         self.file_path = "NULL"
-        #logging.basicConfig()
 
     def poner_radio1(self, radio):
         self.radio1 = radio
@@ -49,16 +46,13 @@ class Puntillism():
     def poner_radio2(self, radio):
         self.radio2 = radio
 
-
     def run(self):
         #size = (1200,900)
         pygame.init()
         pygame.camera.init()
         #camera.init()
-
         self.radio1 = 2
         self.radio2 = 12
-
         self.camNotFound_holder = False  # create a local variable to check camera not found and in loop
 
         screen = pygame.display.get_surface()
@@ -75,10 +69,10 @@ class Puntillism():
             cam = camera.Camera("/dev/video0", (640, 480), "RGB")
             cam.start()
             self.camfound = True
-            
         except SystemError:
             self.running = False
             self.camfound = False
+            
         try:
             cam.set_controls(hflip=True)
         except SystemError:
@@ -116,17 +110,14 @@ class Puntillism():
             print("LOG: No /dev/video0 found")
             self.camNotFound_holder = True
         
+        # after checking if camera exists, cam is not accepted if /dev/video0 > null
+        # Usually null gives a black screen, before initiating the display
+        # A black screen is filled 
         screen.fill((0,0,0))
         pygame.display.update()
 
         if self.camNotFound_holder:
             self.camNotFoundHandler(screen,frames, x_s, y_s, clock, text, textRect)
-
-        # after checking if camera exists, cam is not accepted if /dev/video0 > null
-        # Usually null gives a black screen, before initiating the display
-        # A black screen is filled 
-
-
 
     def create_rect(self, cad, rect, frames, clock, screen, x_size, y_size):
         for z in range(max(20, int(frames)*10)):
@@ -155,11 +146,9 @@ class Puntillism():
             elif event.type == pygame.VIDEORESIZE:
                 pygame.display.set_mode(event.size, pygame.RESIZABLE)
 
-
             elif event.type == pygame.KEYDOWN:
 
                 if event.key == pygame.K_ESCAPE:
-
                     self.running = False
                     self.camNotFound_holder = False
     
@@ -184,8 +173,7 @@ class Puntillism():
     def camNotFoundHandler(self, screen, frames, x_s, y_s, clock, text, textRect):
         while self.camNotFound_holder:
             
-            if self.file_path != "NULL":
-                    
+            if self.file_path != "NULL":           
                 cad = pygame.image.load(self.file_path).convert_alpha()
                 cad = pygame.transform.scale(cad, (640,480))
                 rect = []

--- a/puntillism.py
+++ b/puntillism.py
@@ -122,7 +122,7 @@ class Puntillism():
             self.parent.jobject.destroy()
             self.parent.chooser.destroy()
         except Exception as e:
-            print("ERROR {}".format(e))
+            print("Warning : Tried to destroy ObjectChoser and jobject ::  {}".format(e))
             pass
 
     def create_rect(self, cad, rect, frames, clock, screen, x_size, y_size):

--- a/puntillism.py
+++ b/puntillism.py
@@ -120,13 +120,6 @@ class Puntillism():
             self.image_load_handler(screen, frames,
                                     x_s, y_s, clock, message, font)
 
-        # Destroy image load events
-        try:
-            self.parent.jobject.destroy()
-            self.parent.chooser.destroy()
-        except Exception as e:
-            print("Warning : Tried to destroy ObjectChoser and jobject ::  {}".format(e))
-            pass
 
     def create_rect(self, cad, rect, frames, clock, screen, x_size, y_size):
         for z in range(max(20, int(frames)*10)):
@@ -187,23 +180,19 @@ class Puntillism():
                         pygame.display.update()
 
                         # Get Image file Path from ObjectChooser
-                        try:
-                            self.file_path = self.parent.choose_image_from_journal_cb()
-                            if self.file_path is not None:
-                                screen.fill((0, 0, 0))
-                                pygame.display.update()
-                                self.running = False
-                                self.load_image_loop = True
-                            else:
-                                # The jobject either didn't return anything
-                                # Some error might have happened, while selecting the image
-                                # Just leave it with the current view, if nothings gone wrong
-                                pygame.display.update()
-                                pass
+                        self.file_path = self.parent.return_image_to_pygame()
+                        if self.file_path is not None:
+                            screen.fill((0, 0, 0))
+                            pygame.display.update()
+                            self.running = False
+                            self.load_image_loop = True
+                        else:
+                            # The jobject either didn't return anything
+                            # Some error might have happened, while selecting the image
+                            # Just leave it with the current view, if nothings gone wrong
+                            pygame.display.update()
+                            pass
 
-                        except Exception as e:
-                            print("warning : ", e)
-                            self.running = True
 
     def image_load_handler(self, screen, frames, x_s, y_s, clock, message, font):
         screen.fill((0, 0, 0))

--- a/puntillism.py
+++ b/puntillism.py
@@ -56,6 +56,9 @@ class Puntillism():
         # create a local variable to check camera not found and in loop
         self.load_image_loop = False
 
+        # Declare a font
+        font = pygame.font.Font('freesansbold.ttf', 32)
+        
         screen = pygame.display.get_surface()
         screen.fill((0, 0, 0))
         pygame.display.flip()
@@ -96,10 +99,10 @@ class Puntillism():
                 Gtk.main_iteration()
 
             events = pygame.event.get()
-            self.read_events(events, screen)
+            self.read_events(events, screen, font, x_s, y_s)
 
         # define some colors for not cam found
-        font = pygame.font.Font('freesansbold.ttf', 32)
+        
         message = _('Camera not found')
 
 
@@ -146,7 +149,7 @@ class Puntillism():
         clock.tick()
         frames = clock.get_fps()
 
-    def read_events(self, events, screen):
+    def read_events(self, events, screen, font, x_s, y_s):
         for event in events:
 
             if event.type == pygame.QUIT:
@@ -173,6 +176,17 @@ class Puntillism():
                         self.parent.save_image(screen)
 
                     if event.action == 'openbutton':
+
+                        # ObjectChooser might take a few seconds to load
+                        # A text message might be needed to reflect the loading ObjectChooser
+                        text = font.render(_("Loading Image Selector..."), True, (255, 255, 255), (0, 0, 0))
+                        text_frame = text.get_rect()
+                        screen.fill((0, 0, 0))
+                        screen.blit(text, text_frame)
+                        text_frame.center = (x_s // 2, y_s // 2)
+                        pygame.display.update()
+
+                        # Get Image file Path from ObjectChooser
                         try:
                             self.file_path = self.parent.choose_image_from_journal_cb()
                             if self.file_path is not None:
@@ -222,4 +236,4 @@ class Puntillism():
                 Gtk.main_iteration()
 
             events = pygame.event.get()
-            self.read_events(events, screen)
+            self.read_events(events, screen, font, x_s, y_s)

--- a/puntillism.py
+++ b/puntillism.py
@@ -84,7 +84,6 @@ class Puntillism():
         x_s, y_s = screen.get_size()
 
         clock = pygame.time.Clock()
-<<<<<<< HEAD
         running = True
         camfound = False
         try:
@@ -95,11 +94,6 @@ class Puntillism():
         except SystemError:
             running = False
             camfound = False
-=======
-
-        cam = camera.Camera("/dev/video0", (640, 480), "RGB")
-        cam.start()
->>>>>>> 74965ff70703843755c60a96533e68ebe61fdcde
         try:
             cam.set_controls(hflip=True)
         except SystemError:

--- a/puntillism.py
+++ b/puntillism.py
@@ -166,11 +166,22 @@ class Puntillism():
                         self.parent.save_image(screen)
 
                     if event.action == 'openbutton':
-                        self.file_path = self.parent.choose_image_from_journal_cb()
-                        screen.fill((0, 0, 0))
-                        pygame.display.update()
-                        self.running = False
-                        self.load_image_loop = True
+                        try:
+                            self.file_path = self.parent.choose_image_from_journal_cb()
+                            if self.file_path is not None:
+                                screen.fill((0, 0, 0))
+                                pygame.display.update()
+                                self.running = False
+                                self.load_image_loop = True
+                            else:
+                                # The jobject either didn't return anything
+                                # Some error might have happened, while selecting the image
+                                # Just leave it with the current view, if nothings gone wrong
+                                pass
+
+                        except Exception as e:
+                            print("warning : ", e)
+                            self.running = True
 
     def image_load_handler(self, screen, frames, x_s, y_s, clock, text, text_frame):
         while self.load_image_loop:

--- a/puntillism.py
+++ b/puntillism.py
@@ -100,9 +100,8 @@ class Puntillism():
 
         # define some colors for not cam found
         font = pygame.font.Font('freesansbold.ttf', 32)
-        text = font.render(_('Camera not found'), True, (255, 255, 255), (0, 0, 0))
-        text_frame = text.get_rect()
-        text_frame.center = (x_s // 2, y_s // 2)
+        message = _('Camera not found')
+
 
         if not self.has_camera:
             print("LOG: No /dev/video0 found")
@@ -116,7 +115,7 @@ class Puntillism():
 
         if self.load_image_loop:
             self.image_load_handler(screen, frames,
-                                    x_s, y_s, clock, text, text_frame)
+                                    x_s, y_s, clock, message, font)
 
         # Destroy image load events
         try:
@@ -162,7 +161,7 @@ class Puntillism():
                 if event.key == pygame.K_ESCAPE:
                     self.running = False
                     self.load_image_loop = False
-                    
+
                 elif event.key == pygame.K_s:
                     self.parent.save_image(screen)
 
@@ -192,14 +191,22 @@ class Puntillism():
                             print("warning : ", e)
                             self.running = True
 
-    def image_load_handler(self, screen, frames, x_s, y_s, clock, text, text_frame):
+    def image_load_handler(self, screen, frames, x_s, y_s, clock, message, font):
         screen.fill((0, 0, 0))
         pygame.display.update()
+
+        if not self.has_camera:
+            text = font.render(message, True, (255, 255, 255), (0, 0, 0))
+            text_frame = text.get_rect()
+            text_frame.center = (x_s // 2, y_s // 2)
+        else:
+            text = font.render(_("Click the Load Image Button"), True, (255, 255, 255), (0, 0, 0))
+            text_frame = text.get_rect()
+            text_frame.center = (x_s // 2, y_s // 2)
 
         while self.load_image_loop:
 
             if self.file_path is not None:
-
                 cad = pygame.image.load(self.file_path).convert()
                 cad = pygame.transform.scale(cad, (640, 480))
                 rect = []

--- a/puntillism.py
+++ b/puntillism.py
@@ -31,6 +31,7 @@ try:
     from pygame import camera
 except (ImportError, ModuleNotFoundError):
     print('Error in import Pygame. This activity requires Pygame 1.9')
+from gettext import gettext as _
 
 
 class Puntillism():
@@ -100,7 +101,7 @@ class Puntillism():
         green0 = (0, 255, 0)
         blue0 = (0, 0, 128)
         font = pygame.font.Font('freesansbold.ttf', 32)
-        text = font.render('Camera not found', True, green0, blue0)
+        text = font.render(_('Camera not found'), True, green0, blue0)
         textRect = text.get_rect()
         textRect.center = (x_s // 2, y_s // 2)
 

--- a/puntillism.py
+++ b/puntillism.py
@@ -107,8 +107,8 @@ class Puntillism():
             green0 = (0, 255, 0) 
             white0 = (255, 255, 255) 
             blue0 = (0, 0, 128) 
-            font = pygame.font.Font('freesansbold.ttf', 16)
-            text = font.render('uh-oh! You doesn\'t seem to have a Camera. Use Open Image option', True, green0, blue0) 
+            font = pygame.font.Font('freesansbold.ttf', 32)
+            text = font.render('Camera not found', True, green0, blue0) 
             textRect = text.get_rect() 
             textRect.center = (x_s // 2, y_s // 2)
             print("LOG: No /dev/video0 found")
@@ -117,123 +117,87 @@ class Puntillism():
             pygame.display.update() 
         
         while (not camfound) and camNotFound_holder:
-    
-            # print(self.file_path) Uncomment this line to know file path
-            # For debuggers only
             
             if self.file_path != "NULL":
                   
                 cad = pygame.image.load(self.file_path).convert_alpha()
                 cad = pygame.transform.scale(cad, (640,480))
                 rect = []
-                
-                for z in range(max(20, int(frames)*10)):
-                    x = random.random()
-                    y = random.random()
-                    if self.radio1 > self.radio2:
-                        aux = self.radio2
-                        self.radio2 = self.radio1
-                        self.radio1 = aux
-                    elif self.radio1 == self.radio2:
-                        self.radio2 = self.radio2 + 1
-                    num = random.randrange(self.radio1, self.radio2, 1)
-                    
-                    rect.append(pygame.draw.circle(screen, cad.get_at((int(x * 640), int(y * 480))), (int(x * x_s), int(y * y_s)), num, 0))
-                pygame.display.update(rect)
+                self.create_rect(cad, rect)
 
             else:
-                
                 screen.fill((0,0,0)) 
                 screen.blit(text, textRect) 
                 pygame.display.update()
-            
-            clock.tick()
-            frames = clock.get_fps()
 
             #GTK events
             while Gtk.events_pending():
                 Gtk.main_iteration()
 
             events = pygame.event.get()
-            for event in events:
-                #log.debug( "Event: %s", event )
-                if event.type == pygame.QUIT:
-                    camNotFound_holder = False
-                    
-                elif event.type == pygame.VIDEORESIZE:
-                    pygame.display.set_mode(event.size, pygame.RESIZABLE)
-                elif event.type == pygame.KEYDOWN:
-                    if event.key == pygame.K_ESCAPE:
-                        
-                        camNotFound_holder = False
-                    elif event.key == pygame.K_s:
-                        self.parent.save_image(screen)
-                elif event.type == pygame.USEREVENT:
-                    if hasattr(event,'action'):
-                        if event.action == 'savebutton':
-                            self.parent.save_image(screen)
-                        if event.action == 'openbutton':
-                            #global file_path
-                            print("OPEN")
-                            self.file_path = self.parent.choose_image_from_journal_cb()
-                            # print(">.... ", self.file_path)
-                            print("LOG: File Loaded Successfully")
-                            screen.fill((0,0,0)) 
-                            
-                            
+            self.read_events(events)
 
         # after checking if camera exists, cam is not accepted if /dev/video0 > null
         # Usually null gives a black screen, before initiating the display
         # A black screen is filled 
+
         if running:
             screen.fill((0,0,0))
             pygame.display.update()
 
         while running:
             cap = cam.get_image(cap)
-            # Command for loading image cad = pygame.image.load("xx.png").convert_alpha()
-            # print(cap, type(cap), cad, type(cad), "CAAAAAAAAAAAAAAAAAAAAAAAAAAP")
             rect = []
-            
-
-            for z in range(max(20, int(frames)*10)):
-                x = random.random()
-                y = random.random()
-                if self.radio1 > self.radio2:
-                    aux = self.radio2
-                    self.radio2 = self.radio1
-                    self.radio1 = aux
-                elif self.radio1 == self.radio2:
-                    self.radio2 = self.radio2 + 1
-                num = random.randrange(self.radio1, self.radio2, 1)
-                rect.append(pygame.draw.circle(screen, cap.get_at((int(x * 640), int(y * 480))), (int(x * x_s), int(y * y_s)), num, 0))
-            pygame.display.update(rect)
-
-            clock.tick()
-            frames = clock.get_fps()
+            self.create_rect(cap, rect)
 
             #GTK events
             while Gtk.events_pending():
                 Gtk.main_iteration()
 
             events = pygame.event.get()
-            for event in events:
-                #log.debug( "Event: %s", event )
-                if event.type == pygame.QUIT:
-                    cam.stop()
-                    running = False
-                elif event.type == pygame.VIDEORESIZE:
-                    pygame.display.set_mode(event.size, pygame.RESIZABLE)
-                elif event.type == pygame.KEYDOWN:
-                    if event.key == pygame.K_ESCAPE:
-                        cam.stop()
-                        running = False
-                    elif event.key == pygame.K_s:
+            self.read_events(events)
+
+    def create_rect(self, cad, rect)
+        for z in range(max(20, int(frames)*10)):
+            x = random.random()
+            y = random.random()
+            if self.radio1 > self.radio2:
+                aux = self.radio2
+                self.radio2 = self.radio1
+                self.radio1 = aux
+            elif self.radio1 == self.radio2:
+                self.radio2 = self.radio2 + 1
+            num = random.randrange(self.radio1, self.radio2, 1)
+            
+            rect.append(pygame.draw.circle(screen, cad.get_at((int(x * 640), int(y * 480))), (int(x * x_s), int(y * y_s)), num, 0))
+        pygame.display.update(rect)
+        clock.tick()
+        frames = clock.get_fps()
+    
+    def read_events(self, events):
+        for event in events:
+            
+            if event.type == pygame.QUIT:
+                camNotFound_holder = False
+                
+            elif event.type == pygame.VIDEORESIZE:
+                pygame.display.set_mode(event.size, pygame.RESIZABLE)
+
+            elif event.type == pygame.KEYDOWN:
+
+                if event.key == pygame.K_ESCAPE:
+                    camNotFound_holder = False
+
+                elif event.key == pygame.K_s:
+                    self.parent.save_image(screen)
+
+            elif event.type == pygame.USEREVENT:
+
+                if hasattr(event,'action'):
+
+                    if event.action == 'savebutton':
                         self.parent.save_image(screen)
-                elif event.type == pygame.USEREVENT:
-                    if hasattr(event,'action'):
-                        if event.action == 'savebutton':
-                            self.parent.save_image(screen)
-            #pygame.display.flip()
 
-
+                    if event.action == 'openbutton':
+                        self.file_path = self.parent.choose_image_from_journal_cb()
+                        screen.fill((0,0,0)) 


### PR DESCRIPTION
Fixes https://github.com/sugarlabs/pointillism-activity/issues/17

Pointillism shows a black screen which means nothing for a user who doesn't have a camera
To make it more meaningful, the GCI task requested us to show a message that a camera 
is necessary for pointillism to work.

# [FEATURE PROPOSAL] Load an Image to pointillism
## Issues Faced Previously
pointillism has an issue of not working on systems without a camera.
This PR gives a warning message that a camera is not present if 
`/dev/video.` does not exist.

## Methodology
* Utilize the absence of camera to load an image

## Screenshots
![Screenshot from 2019-12-17 15-48-02](https://user-images.githubusercontent.com/48695438/70996858-bb95a400-20e4-11ea-99f8-22bd0eebc295.png)
Image of Pointiliism showing a friendly Error Message in the absence of camera
Notice the new open toolbar button.
![Screenshot from 2019-12-17 15-53-22](https://user-images.githubusercontent.com/48695438/70997150-6b6b1180-20e5-11ea-96c9-e6154361eb60.png)
An image of the Image Loader from Journal
![Pointillism](https://user-images.githubusercontent.com/48695438/70996965-fd264f00-20e4-11ea-8555-c8677a90a5b0.png)
Image of Pointillism converting a screenshot of speak activity

