### PR TITLE
Add Pause Button and other fixes. Fixes #20 [GCI] 

### DIFF
--- a/activity.py
+++ b/activity.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
 # Pointillism
@@ -203,3 +203,8 @@ class Activity(activity.Activity):
 
     def get_preview(self):
         return self._pygamecanvas.get_preview()
+
+    def can_close(self):
+        self.actividad.load_image_loop = False
+        self.actividad.running = False
+        return True

--- a/activity.py
+++ b/activity.py
@@ -52,6 +52,7 @@ class Activity(activity.Activity):
         self.file_path_temp = None
         self.radio_uno = 2
         self.radio_dos = 12
+        self.paused = False
 
         self.actividad = puntillism.Puntillism(self)
 
@@ -131,14 +132,24 @@ class Activity(activity.Activity):
         barra.insert(open_button, 8)
         open_button.show()
 
+        # Pause/Play button:
+
+        pause_play = ToolButton('media-playback-pause')
+        pause_play.set_tooltip(_("Pause"))
+        pause_play.set_accelerator(_('<ctrl>space'))
+        pause_play.connect('clicked', self._pause_play_cb)
+        pause_play.show()
+
+        toolbar_box.toolbar.insert(pause_play, 9)
+
         separator2 = Gtk.SeparatorToolItem()
         separator2.props.draw = False
         separator2.set_expand(True)
-        barra.insert(separator2, 9)
+        barra.insert(separator2, 10)
 
         stop_button = StopButton(self)
         stop_button.props.accelerator = '<Ctrl>q'
-        barra.insert(stop_button, 10)
+        barra.insert(stop_button, -1)
         stop_button.show()
 
         self.set_toolbar_box(toolbar_box)
@@ -196,6 +207,19 @@ class Activity(activity.Activity):
                 self.chooser.destroy()
                 del self.chooser
                 return self.file_path_temp
+
+    def _pause_play_cb(self, button):
+        # Pause or unpause the game.
+        self.paused = not self.paused
+        self.actividad.set_paused(self.paused)
+
+        # Update the button to show the next action.
+        if self.paused:
+            button.set_icon_name('media-playback-start')
+            button.set_tooltip(_("Start"))
+        else:
+            button.set_icon_name('media-playback-pause')
+            button.set_tooltip(_("Pause"))
 
     def return_image_to_pygame(self):
         self.file_path_temp = self.choose_image_from_journal_cb()

--- a/po/Pointillism.pot
+++ b/po/Pointillism.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-12-21 20:12+0300\n"
+"POT-Creation-Date: 2020-01-16 16:17+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Content-Type: text/plain; charset=CHARSET\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: activity/activity.info:2 activity.py:159
+#: activity/activity.info:2 activity.py:172
 msgid "Pointillism"
 msgstr ""
 
@@ -25,30 +25,38 @@ msgstr ""
 msgid "Create a pointillist image from the camera"
 msgstr ""
 
-#: activity.py:83
+#: activity.py:85
 msgid "Circles between"
 msgstr ""
 
-#: activity.py:102
+#: activity.py:104
 msgid "and"
 msgstr ""
 
-#: activity.py:122
+#: activity.py:124
 msgid "Save Image"
 msgstr ""
 
-#: activity.py:128
+#: activity.py:130
 msgid "Open Image"
 msgstr ""
 
-#: puntillism.py:106
+#: activity.py:138 activity.py:222
+msgid "Pause"
+msgstr ""
+
+#: activity.py:139
+msgid "<ctrl>space"
+msgstr ""
+
+#: activity.py:219
+msgid "Start"
+msgstr ""
+
+#: puntillism.py:109
 msgid "Camera not found"
 msgstr ""
 
-#: puntillism.py:175
-msgid "Loading Image Selector..."
-msgstr ""
-
-#: puntillism.py:206
+#: puntillism.py:214
 msgid "Click the Load Image Button"
 msgstr ""

--- a/puntillism.py
+++ b/puntillism.py
@@ -39,12 +39,16 @@ class Puntillism():
     def __init__(self, parent):
         self.parent = parent
         self.file_path = "NULL"
+        self._paused = False
 
     def poner_radio1(self, radio):
         self.radio1 = radio
 
     def poner_radio2(self, radio):
         self.radio2 = radio
+
+    def set_paused(self, paused):
+        self._paused = paused
 
     def run(self):
         pygame.init()
@@ -120,6 +124,8 @@ class Puntillism():
 
     def create_rect(self, cad, rect, frames, clock, screen, x_size, y_size):
         for z in range(max(20, int(frames)*10)):
+            if self._paused:
+                break
             x = random.random()
             y = random.random()
             if self.radio1 > self.radio2:

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from sugar3.activity import bundlebuilder
 if __name__ == "__main__":
     bundlebuilder.start()


### PR DESCRIPTION
Closes #20 

## Feature: Add Pause Button
This PR has been made because #31 has not made any progress in the review process. 
See Commit message for more details https://github.com/sugarlabs/pointillism-activity/commit/69d70eb7e9afb2fac45aaecf3aeddd242d3291d9

## Additional Fixes
* https://github.com/sugarlabs/pointillism-activity/commit/ce2245bd3e58a52f13b778a6eb8d985a9e987761 Update shebangs to python3
* https://github.com/sugarlabs/pointillism-activity/commit/1127e82e9b78055499850a3c0dbfa7357ac36b0f Add safe closing by implementing a `can_close` method override 

## Tests
* Coverage
```
activity.py                       96%
puntillism (with camera)          76%
puntillism (without camera)       84%
```
* Fix redraw error when switching activities (Known Issue (also on master) , on reswitch, pointillism will not start from where it was stopped. On Pause and play without switching, the activity resumes correctly)
* Tested with Sugar ISO
* Tested on Sugar DE
* `dist_xo` compiled successfully 
* Test plans mentioned [here](https://github.com/sugarlabs/sugar-docs/blob/master/src/contributing.md#testing)